### PR TITLE
clip metadata

### DIFF
--- a/launcher/components/Clip.qml
+++ b/launcher/components/Clip.qml
@@ -94,14 +94,29 @@ IComponent {
                     anchors.margins: Launcher.innerMargin * 2
                     spacing: Launcher.innerMargin * 2
 
-                    IText {
-                        text: modelData?.isImage ? "Image" : "Text" || ""
+                    IconImage {
+                        source: modelData?.appIcon
+                        implicitSize: parent.height
                     }
-                    IText {
-                        text: modelData?.timestamp || ""
-                    }
-                    IText {
-                        text: modelData?.data || ""
+
+                    Column {
+                        IText {
+                            text: modelData?.data || ""
+                            font.pixelSize: Style.font.size.largerr
+                        }
+                        Row {
+                            spacing: Launcher.innerMargin
+                            IText {
+                                text: modelData.isImage ? "Image" : "Text"
+                                color: Colors.foreground3
+                                font.pixelSize: Style.font.size.normal
+                            }
+                            IText {
+                                text: TimeDate.sinceWhen(modelData?.timestamp) || ""
+                                color: Colors.foreground3
+                                font.pixelSize: Style.font.size.normal
+                            }
+                        }
                     }
                 }
 

--- a/launcher/components/Clip.qml
+++ b/launcher/components/Clip.qml
@@ -98,6 +98,9 @@ IComponent {
                         text: modelData?.isImage ? "Image" : "Text" || ""
                     }
                     IText {
+                        text: modelData?.timestamp || ""
+                    }
+                    IText {
                         text: modelData?.data || ""
                     }
                 }

--- a/services/Clip.qml
+++ b/services/Clip.qml
@@ -4,7 +4,10 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import QtQuick
+
 import qs.components
+import qs.utils
+import qs.services
 
 Searchable {
     id: root
@@ -56,6 +59,24 @@ Searchable {
                 appTitle: metadata.appTitle || ""
             };
         });
+    }
+
+    Persistent {
+        id: clipMetaStore
+        filePath: Directories.clipHistMetaDataPath
+        adapter: JsonAdapter {
+            property var metadata: ({})
+        }
+        fileView.onLoaded: {
+            root._clipMetadata = adapter.metadata;
+        }
+        // fileView.onAdapterUpdated: {
+        //     root._clipMetadata = adapter.metadata;
+        // }
+    }
+
+    on_ClipMetadataChanged: {
+        clipMetaStore.adapter.metadata = _clipMetadata;
     }
 
     function transformSearch(search) {

--- a/services/Clip.qml
+++ b/services/Clip.qml
@@ -3,7 +3,6 @@ pragma Singleton
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
-import QtQuick
 
 import qs.components
 import qs.utils

--- a/services/Clip.qml
+++ b/services/Clip.qml
@@ -56,7 +56,8 @@ Searchable {
                 raw: raw,
                 timestamp: metadata.timestamp || "",
                 appId: metadata.appId || "",
-                appTitle: metadata.appTitle || ""
+                appTitle: metadata.appTitle || "",
+                appIcon: Quickshell.iconPath(AppSearch.guessIcon(metadata.appId), "image-missing")
             };
         });
     }
@@ -68,7 +69,13 @@ Searchable {
             property var metadata: ({})
         }
         fileView.onLoaded: {
-            root._clipMetadata = adapter.metadata;
+            const meta = adapter.metadata;
+            for (const k in meta) {
+                if (meta[k].timestamp && typeof meta[k].timestamp === "string") {
+                    meta[k].timestamp = new Date(meta[k].timestamp);
+                }
+            }
+            root._clipMetadata = meta;
         }
         // fileView.onAdapterUpdated: {
         //     root._clipMetadata = adapter.metadata;
@@ -116,6 +123,7 @@ Searchable {
                             if (_clipMetadata.hasOwnProperty(k))
                                 newMetadata[k] = _clipMetadata[k];
                         }
+
                         newMetadata[idStr] = {
                             timestamp: now,
                             appId: activeToplevel ? activeToplevel.appId : "",

--- a/services/Clip.qml
+++ b/services/Clip.qml
@@ -15,6 +15,8 @@ Searchable {
     property list<string> _clipImg: []
     property list<string> _clipImgIds: _clipImg.map(p => p.split("/").pop().split(".").shift())
 
+    property var _clipMetadata: ({})
+
     list: {
         if (!_clipHist?.length)
             return [];

--- a/services/Persistent.qml
+++ b/services/Persistent.qml
@@ -1,0 +1,27 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.utils
+
+Scope {
+    id: root
+    property alias adapter: fileView.adapter
+    property alias fileView: fileView
+    property string fileDir: Directories.state
+    property string fileName: "states.json"
+    property string filePath: `${root.fileDir}/${root.fileName}`
+
+    FileView {
+        id: fileView
+        path: root.filePath
+        watchChanges: true
+        onFileChanged: reload()
+        onAdapterUpdated: writeAdapter()
+        onLoadFailed: error => {
+            console.log("Failed to load persistent states file:", error);
+            if (error == FileViewError.FileNotFound) {
+                writeAdapter();
+            }
+        }
+    }
+}

--- a/services/TimeDate.qml
+++ b/services/TimeDate.qml
@@ -72,16 +72,7 @@ Singleton {
         }
 
         var ymd = Qt.formatDateTime(d, "yyyy-MM-dd");
-        var h24 = d.getHours();
-        var m = d.getMinutes();
-
-        var h12 = h24 % 12;
-        if (h12 === 0)
-            h12 = 12;
-        var ampm = h24 < 12 ? "AM" : "PM";
-        var hhmm = (h12 < 10 ? "0" : "") + h12 + (m < 10 ? "0" : "") + m + " " + ampm;
-
-        return ymd + " at " + hhmm;
+        return ymd + " at " + fmt12h(d);
     }
 
     SystemClock {

--- a/services/TimeDate.qml
+++ b/services/TimeDate.qml
@@ -27,6 +27,60 @@ Singleton {
 
     readonly property string date: Qt.formatDateTime(clock.date, "dddd dd/MM")
 
+    function sinceWhen(d: Date) {
+        var now = clock.date;
+
+        function startOfDay(x) {
+            return new Date(x.getFullYear(), x.getMonth(), x.getDate(), 0, 0, 0, 0);
+        }
+
+        function startOfWeek(x) {
+            var dow = x.getDay();
+            var mondayOffset = (dow + 6) % 7;
+            var sod = startOfDay(x);
+            sod.setDate(sod.getDate() - mondayOffset);
+            return sod;
+        }
+
+        function fmt12h(dateObj) {
+            var h24 = dateObj.getHours();
+            var m = dateObj.getMinutes();
+            var h12 = h24 % 12;
+            if (h12 === 0)
+                h12 = 12;
+            var ampm = h24 < 12 ? "AM" : "PM";
+            return ((h12 < 10 ? "0" : "") + h12 + ":" + (m < 10 ? "0" : "") + m + " " + ampm);
+        }
+
+        function weekdayName(dateObj) {
+            return Qt.formatDateTime(dateObj, "dddd");
+        }
+
+        var nowSOD = startOfDay(now).getTime();
+        var dSOD = startOfDay(d).getTime();
+        if (nowSOD === dSOD) {
+            return fmt12h(d);
+        }
+
+        var nowSOW = startOfWeek(now).getTime();
+        var dSOW = startOfWeek(d).getTime();
+        if (nowSOW === dSOW) {
+            return weekdayName(d) + " " + fmt12h(d);
+        }
+
+        var ymd = Qt.formatDateTime(d, "yyyy-MM-dd");
+        var h24 = d.getHours();
+        var m = d.getMinutes();
+
+        var h12 = h24 % 12;
+        if (h12 === 0)
+            h12 = 12;
+        var ampm = h24 < 12 ? "AM" : "PM";
+        var hhmm = (h12 < 10 ? "0" : "") + h12 + (m < 10 ? "0" : "") + m + " " + ampm;
+
+        return ymd + " hour:" + hhmm;
+    }
+
     SystemClock {
         id: clock
         precision: SystemClock.Seconds

--- a/services/TimeDate.qml
+++ b/services/TimeDate.qml
@@ -81,7 +81,7 @@ Singleton {
         var ampm = h24 < 12 ? "AM" : "PM";
         var hhmm = (h12 < 10 ? "0" : "") + h12 + (m < 10 ? "0" : "") + m + " " + ampm;
 
-        return ymd + " hour:" + hhmm;
+        return ymd + " at " + hhmm;
     }
 
     SystemClock {

--- a/services/TimeDate.qml
+++ b/services/TimeDate.qml
@@ -27,7 +27,10 @@ Singleton {
 
     readonly property string date: Qt.formatDateTime(clock.date, "dddd dd/MM")
 
-    function sinceWhen(d: Date) {
+    function sinceWhen(d) {
+        if (typeof d === "string")
+            return;
+
         var now = clock.date;
 
         function startOfDay(x) {

--- a/utils/Directories.qml
+++ b/utils/Directories.qml
@@ -55,9 +55,6 @@ Singleton {
 
     // Cleanup on init
     Component.onCompleted: {
-        Quickshell.execDetached(["sh", "-c", `mkdir -p '${shellConfig}'`]);
-        Quickshell.execDetached(["sh", "-c", `mkdir -p '${favicons}'`]);
-        Quickshell.execDetached(["sh", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`]);
         Quickshell.execDetached(["touch", trimFileProtocol(clipHistMetaDataPath)]);
     }
 }

--- a/utils/Directories.qml
+++ b/utils/Directories.qml
@@ -1,0 +1,78 @@
+pragma Singleton
+// pragma ComponentBehavior: Bound
+
+import Qt.labs.platform
+import QtQuick
+import Quickshell
+import Quickshell.Hyprland
+
+Singleton {
+    /**
+ * Trims the File protocol off the input string
+ * @param {string} str
+ * @returns {string}
+ */
+    function trimFileProtocol(str) {
+        return str.startsWith("file://") ? str.slice(7) : str;
+    }
+
+    /**
+ * Extracts the file name from a file path
+ * @param {string} str
+ * @returns {string}
+ */
+    function fileNameForPath(str) {
+        if (typeof str !== "string")
+            return "";
+        const trimmed = trimFileProtocol(str);
+        return trimmed.split(/[\\/]/).pop();
+    }
+
+    /**
+ * Removes the file extension from a file path or name
+ * @param {string} str
+ * @returns {string}
+ */
+    function trimFileExt(str) {
+        if (typeof str !== "string")
+            return "";
+        const trimmed = trimFileProtocol(str);
+        const lastDot = trimmed.lastIndexOf(".");
+        if (lastDot > -1 && lastDot > trimmed.lastIndexOf("/")) {
+            return trimmed.slice(0, lastDot);
+        }
+        return trimmed;
+    }
+
+    // XDG Dirs, with "file://"
+    readonly property string config: StandardPaths.standardLocations(StandardPaths.ConfigLocation)[0]
+    readonly property string state: StandardPaths.standardLocations(StandardPaths.StateLocation)[0]
+    readonly property string cache: StandardPaths.standardLocations(StandardPaths.CacheLocation)[0]
+    readonly property string pictures: StandardPaths.standardLocations(StandardPaths.PicturesLocation)[0]
+    readonly property string downloads: StandardPaths.standardLocations(StandardPaths.DownloadLocation)[0]
+
+    // Other dirs used by the shell, without "file://"
+    property string scriptPath: trimFileProtocol(`${Directories.config}/quickshell/scripts`)
+    property string favicons: trimFileProtocol(`${Directories.cache}/media/favicons`)
+    property string coverArt: trimFileProtocol(`${Directories.cache}/media/coverart`)
+    property string booruPreviews: trimFileProtocol(`${Directories.cache}/media/boorus`)
+    property string booruDownloads: trimFileProtocol(Directories.pictures + "/homework")
+    property string booruDownloadsNsfw: trimFileProtocol(Directories.pictures + "/homework/🌶️")
+    property string latexOutput: trimFileProtocol(`${Directories.cache}/media/latex`)
+    property string shellConfig: trimFileProtocol(`${Directories.config}/illogical-impulse`)
+    property string shellConfigName: "config.json"
+    property string shellConfigPath: `${Directories.shellConfig}/${Directories.shellConfigName}`
+    property string todoPath: trimFileProtocol(`${Directories.state}/user/todo.json`)
+    property string notificationsPath: trimFileProtocol(`${Directories.cache}/notifications/notifications.json`)
+    property string generatedMaterialThemePath: trimFileProtocol(`${Directories.state}/user/generated/colors.json`)
+    property string cliphistDecode: trimFileProtocol(`/tmp/quickshell/media/cliphist`)
+    property string wallpaperSwitchScriptPath: trimFileProtocol(`${Directories.scriptPath}/colors/switchwall.sh`)
+    property string defaultAiPrompts: trimFileProtocol(`${Directories.config}/quickshell/defaults/ai/prompts`)
+    property string userAiPrompts: trimFileProtocol(`${Directories.shellConfig}/ai/prompts`)
+    // Cleanup on init
+    Component.onCompleted: {
+        Quickshell.execDetached(["bash", "-c", `mkdir -p '${shellConfig}'`]);
+        Quickshell.execDetached(["bash", "-c", `mkdir -p '${favicons}'`]);
+        Quickshell.execDetached(["bash", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`]);
+    }
+}

--- a/utils/Directories.qml
+++ b/utils/Directories.qml
@@ -51,28 +51,13 @@ Singleton {
     readonly property string pictures: StandardPaths.standardLocations(StandardPaths.PicturesLocation)[0]
     readonly property string downloads: StandardPaths.standardLocations(StandardPaths.DownloadLocation)[0]
 
-    // Other dirs used by the shell, without "file://"
-    property string scriptPath: trimFileProtocol(`${Directories.config}/quickshell/scripts`)
-    property string favicons: trimFileProtocol(`${Directories.cache}/media/favicons`)
-    property string coverArt: trimFileProtocol(`${Directories.cache}/media/coverart`)
-    property string booruPreviews: trimFileProtocol(`${Directories.cache}/media/boorus`)
-    property string booruDownloads: trimFileProtocol(Directories.pictures + "/homework")
-    property string booruDownloadsNsfw: trimFileProtocol(Directories.pictures + "/homework/🌶️")
-    property string latexOutput: trimFileProtocol(`${Directories.cache}/media/latex`)
-    property string shellConfig: trimFileProtocol(`${Directories.config}/illogical-impulse`)
-    property string shellConfigName: "config.json"
-    property string shellConfigPath: `${Directories.shellConfig}/${Directories.shellConfigName}`
-    property string todoPath: trimFileProtocol(`${Directories.state}/user/todo.json`)
-    property string notificationsPath: trimFileProtocol(`${Directories.cache}/notifications/notifications.json`)
-    property string generatedMaterialThemePath: trimFileProtocol(`${Directories.state}/user/generated/colors.json`)
-    property string cliphistDecode: trimFileProtocol(`/tmp/quickshell/media/cliphist`)
-    property string wallpaperSwitchScriptPath: trimFileProtocol(`${Directories.scriptPath}/colors/switchwall.sh`)
-    property string defaultAiPrompts: trimFileProtocol(`${Directories.config}/quickshell/defaults/ai/prompts`)
-    property string userAiPrompts: trimFileProtocol(`${Directories.shellConfig}/ai/prompts`)
+    property string clipHistMetaDataPath: `${state}/cliphist.json`
+
     // Cleanup on init
     Component.onCompleted: {
-        Quickshell.execDetached(["bash", "-c", `mkdir -p '${shellConfig}'`]);
-        Quickshell.execDetached(["bash", "-c", `mkdir -p '${favicons}'`]);
-        Quickshell.execDetached(["bash", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`]);
+        Quickshell.execDetached(["sh", "-c", `mkdir -p '${shellConfig}'`]);
+        Quickshell.execDetached(["sh", "-c", `mkdir -p '${favicons}'`]);
+        Quickshell.execDetached(["sh", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`]);
+        Quickshell.execDetached(["touch", trimFileProtocol(clipHistMetaDataPath)]);
     }
 }


### PR DESCRIPTION
- **refactor(clip): use Quickshell.execDetached when avaliable**
- **cleanup: remove legacy state.exec**
- **utils(cliphist-img): use $XDG_CACHE_HOME**
- **fix(NetworkUsage): rerun getRouteProc when defaultInterface errs**
- **m**
- **presist**
- **fix: use Overlay for launcher**
- **cleanup(ActiveWindow): use implicitSize for same implicit{Width,Height}**
- **fix(SelectionState): activeRect not following selected when new priority appears that is higher priority then previous**
- **done**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard history now shows per-item app icon, app title, and timestamp, with metadata persisted across sessions.
  * Added a reusable persistent storage service and a date-format helper for readable timestamps.
  * New utilities for standard filesystem paths and filename helpers.

* **Style**
  * Refined clipboard list layout: main content above, metadata below, with consistent app icon sizing.
  * Unified icon sizing for active-window indicators for a cleaner UI.

* **Bug Fixes**
  * Improved network usage widget reliability by hardening route/interface detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->